### PR TITLE
Adding constructor to xarraySlice

### DIFF
--- a/algoim/xarray.hpp
+++ b/algoim/xarray.hpp
@@ -69,6 +69,8 @@ namespace algoim
         T* ptr;
         int len;
 
+        xarraySlice(T *ptr, int len) : ptr(ptr), len(len){};
+
         xarraySlice(xarraySlice&) = delete;
         xarraySlice(xarraySlice&&) = delete;
 


### PR DESCRIPTION
Modern Apple clang (16.0.0) complains with message error: no matching constructor for initialization of 'xarraySlice<double>'
            return xarraySlice<T>{data_ + i * span, span};